### PR TITLE
Document for issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+This is just a basic template better suited for bug reporting, if it is not suitable for the thing you want to report such as a problem with the documentation, feel free to deviate from it.
+
+[provide general introduction to the issue logging and why it is relevant to this repository]
+
+## Context
+
+[provide more detailed introduction to the issue itself and why it is relevant]
+
+## Process
+
+[if applicable; ordered list the process to finding and recreating the issue, example below]
+
+1. User goes to delete a dataset (to save space or whatever)
+2. User gets popup modal warning
+3. User deletes and it's lost forever
+
+## Expected result
+
+[describe what you would expect to have resulted from this process]
+
+## Current result
+
+[describe what you you currently experience from this process, and thereby explain the bug]
+
+## Possible Fix
+
+[not obligatory, but suggest fixes or reasons for the bug]
+
+
+This template was adapted ~retrived~ from [Aurelia Moser](https://bl.ocks.org/auremoser/72803ba969d0e61ff070)


### PR DESCRIPTION
This document is very similiar that we used in
the linked project jp2_online.

What's this PR do?

Add a template that will prefil the issue description box, whenever anyone
reports and issue. 

Where should the reviewer start?

Revieweer should start checks that document is correct and if is consistent with this project

How should this be manually tested?

Just need to review the document.

Any background context you want to provide?

This pull request is add will help to manage the project

This template was adapted retrived from Quickleft/Sprint.ly